### PR TITLE
fixed timeout_sec for read_passive_target

### DIFF
--- a/Adafruit_PN532/PN532.py
+++ b/Adafruit_PN532/PN532.py
@@ -367,7 +367,7 @@ class PN532(object):
         # Send passive read command for 1 card.  Expect at most a 7 byte UUID.
         response = self.call_function(PN532_COMMAND_INLISTPASSIVETARGET,
                                       params=[0x01, card_baud],
-                                      response_length=17)
+                                      response_length=17,timeout_sec=timeout_sec)
         # If no response is available return None to indicate no card is present.
         if response is None:
             return None


### PR DESCRIPTION
timeout_sec for read_passive_target is now passed to call_function, before the timeout value was not passed to the call function, effectively having no use.
