### PR TITLE
Fix response length for 7 byte UID Mifare

### DIFF
--- a/Adafruit_PN532/PN532.py
+++ b/Adafruit_PN532/PN532.py
@@ -367,7 +367,7 @@ class PN532(object):
         # Send passive read command for 1 card.  Expect at most a 7 byte UUID.
         response = self.call_function(PN532_COMMAND_INLISTPASSIVETARGET,
                                       params=[0x01, card_baud],
-                                      response_length=17)
+                                      response_length=19)
         # If no response is available return None to indicate no card is present.
         if response is None:
             return None


### PR DESCRIPTION
Increasing the number of read bytes by 2 in the method read_passive_target()
fixes reading Mifare cards with a UID of length 7.

Previously, the response from the PN532 chip was not read completely and
checksum calculation would fail.
